### PR TITLE
Add option to support releases on new Git tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ deploy:
     on:
       # Create a new release
       #   On cron jobs, or
-      #   When triggered via "Trigger build" on https://travis-ci.org/sindresorhus/refined-github/
+      #   When triggered via "Trigger build"
       branch: master
       condition: ($RELEASE_ON_TAGS = false && (($TRAVIS_EVENT_TYPE = api) || ($TRAVIS_EVENT_TYPE = cron && $(git rev-list -n 1 --since="26 hours ago" master))))
   - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ deploy:
       #   On cron jobs, or
       #   When triggered via "Trigger build" on https://travis-ci.org/sindresorhus/refined-github/
       branch: master
-      condition: ($RELEASE_ON_TAGS = false && (($TRAVIS_EVENT_TYPE = api) || ($TRAVIS_EVENT_TYPE = cron && $(git rev-list -n 1 --since=\"26 hours ago\" master))))
+      condition: ($RELEASE_ON_TAGS = false && (($TRAVIS_EVENT_TYPE = api) || ($TRAVIS_EVENT_TYPE = cron && $(git rev-list -n 1 --since="26 hours ago" master))))
   - provider: script
     skip_cleanup: true
     script: npm run release

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: node_js
 node_js:
   - 'node'
 env:
-  - EXTENSION_ID='extension id for publising to CWS'
-  - RELEASE_ON_TAGS='false'
+  - EXTENSION_ID='extension id for publising to CWS' RELEASE_ON_TAGS='false'
 deploy:
   - provider: script
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,22 @@ node_js:
   - 'node'
 env:
   - EXTENSION_ID='extension id for publising to CWS'
+  - RELEASE_ON_TAGS='false'
 deploy:
-  provider: script
-  skip_cleanup: true
-  script: npm run release
-  on:
-    # Create a new release
-    #   On cron jobs, or
-    #   When triggered via "Trigger build" on https://travis-ci.org/sindresorhus/refined-github/
-    branch: master
-    condition: (($TRAVIS_EVENT_TYPE = api) || ($TRAVIS_EVENT_TYPE = cron && $(git rev-list -n 1 --since=\"26 hours ago\" master)))
+  - provider: script
+    skip_cleanup: true
+    script: npm run release
+    on:
+      # Create a new release
+      #   On cron jobs, or
+      #   When triggered via "Trigger build" on https://travis-ci.org/sindresorhus/refined-github/
+      branch: master
+      condition: ($RELEASE_ON_TAGS = false && (($TRAVIS_EVENT_TYPE = api) || ($TRAVIS_EVENT_TYPE = cron && $(git rev-list -n 1 --since=\"26 hours ago\" master))))
+  - provider: script
+    skip_cleanup: true
+    script: npm run release
+    on:
+      # Create a new release
+      #   On Git tags
+      tags: true
+      condition: $RELEASE_ON_TAGS = true

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"test": "run-s lint:* build",
 		"build": "webpack --mode=production",
 		"watch": "webpack --mode=development --watch",
-		"prerelease:version": "VERSION=$(utc-version); echo $VERSION; dot-json distribution/manifest.json version $VERSION",
+		"prerelease:version": "if [[ $RELEASE_ON_TAGS = true ]]; then VERSION=$(echo $TRAVIS_TAG); else VERSION=$(utc-version); fi; echo $VERSION; dot-json distribution/manifest.json version $VERSION",
 		"prerelease:source-url": "echo https://github.com/sindresorhus/refined-github/tree/\"${TRAVIS_COMMIT:-$VERSION}\" > distribution/SOURCE_URL",
 		"release": "npm-run-all build prerelease:* release:*",
 		"release:cws": "webstore upload --source=distribution --auto-publish",

--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,12 @@ And don't forget to setup a cron job that runs daily on master, and include your
 
 Whenever you want to create a new release or when the extension is auto-published, the current date and time in the format `[year].[month].[date].[hour-minute]` (for example, `19.6.16.428`) is used as the version number. So that you don't have to manually update this number when a new release is to be made.
 
+#### Releases on Git tags
+
+You can also set up Travis to release extension on Git tags. In this case the version will be same as current Git tag. Automatic daily releases will not be triggered in this case.
+
+To set it up, set environment variable `RELEASE_ON_TAGS` to `true` in [.travis.yml](.travis.yml).
+
 #### Manual releases
 
 Releases to the extension are made from the cron job that runs once a day. If you ever wanted to release a new version, like an immediate bug/security fix, you can use the "Trigger build" button on the Travis build page after making the necessary commits. This will trigger the release script and new version will be published.

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@
 - Cross-browser builds using [webextension-polyfill][link-webext-polyfill].
 - [Auto-syncing options](#auto-syncing-options).
 - [Auto-publishing](#auto-publishing) with auto-versioning and support for manual releases.
+- Option to publish on [Git tags](#releases-on-git-tags) instead of auto-publishing.
 - [Extensive configuration documentation](#configuration).
 
 This extension template is heavily inspired from [refined-github][link-rgh], [notifier-for-github][link-ngh], and [hide-files-on-github][link-hfog] browser extensions. You can always refer to these browser extensions' source code if you find anything confusing on how to create a new extension.
@@ -164,15 +165,15 @@ And don't forget to setup a cron job that runs daily on master, and include your
 
 Whenever you want to create a new release or when the extension is auto-published, the current date and time in the format `[year].[month].[date].[hour-minute]` (for example, `19.6.16.428`) is used as the version number. So that you don't have to manually update this number when a new release is to be made.
 
-#### Releases on Git tags
-
-You can also set up Travis to release extension on Git tags. In this case the version will be same as current Git tag. Automatic daily releases will not be triggered in this case.
-
-To set it up, set environment variable `RELEASE_ON_TAGS` to `true` in [.travis.yml](.travis.yml).
-
 #### Manual releases
 
-Releases to the extension are made from the cron job that runs once a day. If you ever wanted to release a new version, like an immediate bug/security fix, you can use the "Trigger build" button on the Travis build page after making the necessary commits. This will trigger the release script and new version will be published.
+Releases to the extension are made from the cron job that runs once a day. If you ever wanted to release a new version, like an immediate bug/security fix, you can use the "Trigger build" button on the Travis build page after making the necessary commits. This will trigger the release script and new version will be published with the versioning method mentioned above.
+
+### Releases on Git tags
+
+You can also set up Travis to release extension on Git tags if you don't want the extension to auto-publish itself. In that case the version with which the extension is released will be same as current Git tag.
+
+To set it up, set the environment variable `RELEASE_ON_TAGS` to `true` in [.travis.yml](.travis.yml). In this case, [automatic daily releases](#auto-publishing) and its respective [versioning](#versioning) method will not be triggered.
 
 ### License
 

--- a/source/options.js
+++ b/source/options.js
@@ -2,8 +2,8 @@ import optionsStorage from './options-storage';
 
 optionsStorage.syncForm('#options-form');
 
-const rangeInputs = [...(document.querySelectorAll('input[type="range"][name^="color"]')];
-const numberInputs = [...(document.querySelectorAll('input[type="number"][name^="color"]')];
+const rangeInputs = [...document.querySelectorAll('input[type="range"][name^="color"]')];
+const numberInputs = [...document.querySelectorAll('input[type="number"][name^="color"]')];
 const output = document.querySelector('.color-output');
 
 function updateColor() {

--- a/source/options.js
+++ b/source/options.js
@@ -2,8 +2,8 @@ import optionsStorage from './options-storage';
 
 optionsStorage.syncForm('#options-form');
 
-const rangeInputs = Array.from(document.querySelectorAll('input[type="range"][name^="color"]'));
-const numberInputs = Array.from(document.querySelectorAll('input[type="number"][name^="color"]'));
+const rangeInputs = [...(document.querySelectorAll('input[type="range"][name^="color"]')];
+const numberInputs = [...(document.querySelectorAll('input[type="number"][name^="color"]')];
 const output = document.querySelector('.color-output');
 
 function updateColor() {


### PR DESCRIPTION
If env var `RELEASE_ON_TAGS` is `true`, it will release extensions on Git tags with version same as Git tag. If it is `false` it will release daily as it was before.

I also use the spread operator instead of `Array.from()` as it was suggested by linting.