### PR TITLE
Simplify deployment code and documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: node_js
 node_js:
-  - 'node'
+  - stable
 env:
-  - EXTENSION_ID='000000000000000000000000000000000' # Extension ID assigned by the Chrome Web Store
+   # Extension ID assigned by the Chrome Web Store
+  - EXTENSION_ID='000000000000000000000000000000000'
 deploy:
   - provider: script
     skip_cleanup: true
     script: npm run release
     on:
-      # Create a new release
-      #   On cron jobs, or
-      #   When triggered via "Trigger build" on Travis
+      # On cron jobs https://docs.travis-ci.com/user/cron-jobs/
+      # When clicking "Trigger build" https://blog.travis-ci.com/2017-08-24-trigger-custom-build
       branch: master
       condition: (($TRAVIS_EVENT_TYPE = api) || ($TRAVIS_EVENT_TYPE = cron && $(git rev-list -n 1 --since=\"26 hours ago\" master)))

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - 'node'
 env:
-  - EXTENSION_ID='extension id for publising to CWS' RELEASE_ON_TAGS='false'
+  - EXTENSION_ID='extension id for publising to CWS'
 deploy:
   - provider: script
     skip_cleanup: true
@@ -10,14 +10,6 @@ deploy:
     on:
       # Create a new release
       #   On cron jobs, or
-      #   When triggered via "Trigger build"
+      #   When triggered via "Trigger build" on Travis
       branch: master
-      condition: ($RELEASE_ON_TAGS = false && (($TRAVIS_EVENT_TYPE = api) || ($TRAVIS_EVENT_TYPE = cron && $(git rev-list -n 1 --since="26 hours ago" master))))
-  - provider: script
-    skip_cleanup: true
-    script: npm run release
-    on:
-      # Create a new release
-      #   On Git tags
-      tags: true
-      condition: $RELEASE_ON_TAGS = true
+      condition: ($TRAVIS_EVENT_TYPE = api || $TRAVIS_EVENT_TYPE = cron) && ($(git tag -l --points-at HEAD) = "")

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ deploy:
       # On cron jobs https://docs.travis-ci.com/user/cron-jobs/
       # When clicking "Trigger build" https://blog.travis-ci.com/2017-08-24-trigger-custom-build
       branch: master
-      condition: (($TRAVIS_EVENT_TYPE = api) || ($TRAVIS_EVENT_TYPE = cron && $(git rev-list -n 1 --since=\"26 hours ago\" master)))
+      condition: (($TRAVIS_EVENT_TYPE = api) || ($TRAVIS_EVENT_TYPE = cron && $(git rev-list --since=yesterday HEAD)))

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - 'node'
 env:
-  - EXTENSION_ID='extension id for publising to CWS'
+  - EXTENSION_ID='000000000000000000000000000000000' # Extension ID assigned by the Chrome Web Store
 deploy:
   - provider: script
     skip_cleanup: true
@@ -12,4 +12,4 @@ deploy:
       #   On cron jobs, or
       #   When triggered via "Trigger build" on Travis
       branch: master
-      condition: ($TRAVIS_EVENT_TYPE = api || $TRAVIS_EVENT_TYPE = cron) && ($(git tag -l --points-at HEAD) = "")
+      condition: (($TRAVIS_EVENT_TYPE = api) || ($TRAVIS_EVENT_TYPE = cron && $(git rev-list -n 1 --since=\"26 hours ago\" master)))

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"build": "webpack --mode=production",
 		"watch": "webpack --mode=development --watch",
 		"prerelease:version": "VERSION=$(utc-version); echo $VERSION; dot-json distribution/manifest.json version $VERSION",
-		"prerelease:source-url": "if [[ $TRAVIS_REPO_SLUG ]]; echo https://github.com/$TRAVIS_REPO_SLUG/tree/\"${TRAVIS_COMMIT:-$VERSION}\" > distribution/SOURCE_URL; fi",
+		"prerelease:source-url": "if [[ $TRAVIS_REPO_SLUG ]]; echo https://github.com/$TRAVIS_REPO_SLUG/tree/\"${TRAVIS_TAG:-$TRAVIS_COMMIT}\" > distribution/SOURCE_URL; fi",
 		"release": "npm-run-all build prerelease:* release:*",
 		"release:cws": "webstore upload --source=distribution --auto-publish",
 		"release:amo": "web-ext-submit --source-dir distribution"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
 		"test": "run-s lint:* build",
 		"build": "webpack --mode=production",
 		"watch": "webpack --mode=development --watch",
-		"prerelease:version": "if [[ $RELEASE_ON_TAGS = true ]]; then VERSION=$(echo $TRAVIS_TAG); else VERSION=$(utc-version); fi; echo $VERSION; dot-json distribution/manifest.json version $VERSION",
-		"prerelease:source-url": "echo https://github.com/$TRAVIS_REPO_SLUG/tree/\"${TRAVIS_COMMIT:-$VERSION}\" > distribution/SOURCE_URL",
+		"prerelease:version": "VERSION=$(utc-version); echo $VERSION; dot-json distribution/manifest.json version $VERSION",
+		"prerelease:source-url": "if [[ $TRAVIS_REPO_SLUG ]]; echo https://github.com/$TRAVIS_REPO_SLUG/tree/\"${TRAVIS_COMMIT:-$VERSION}\" > distribution/SOURCE_URL; fi",
 		"release": "npm-run-all build prerelease:* release:*",
 		"release:cws": "webstore upload --source=distribution --auto-publish",
 		"release:amo": "web-ext-submit --source-dir distribution"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"build": "webpack --mode=production",
 		"watch": "webpack --mode=development --watch",
 		"prerelease:version": "VERSION=$(utc-version); echo $VERSION; dot-json distribution/manifest.json version $VERSION",
-		"prerelease:source-url": "if [[ $TRAVIS_REPO_SLUG ]]; echo https://github.com/$TRAVIS_REPO_SLUG/tree/\"${TRAVIS_TAG:-$TRAVIS_COMMIT}\" > distribution/SOURCE_URL; fi",
+		"prerelease:source-url": "if [[ $TRAVIS_REPO_SLUG ]]; then echo https://github.com/$TRAVIS_REPO_SLUG/tree/\"${TRAVIS_TAG:-$TRAVIS_COMMIT}\" > distribution/SOURCE_URL; fi",
 		"release": "npm-run-all build prerelease:* release:*",
 		"release:cws": "webstore upload --source=distribution --auto-publish",
 		"release:amo": "web-ext-submit --source-dir distribution"

--- a/readme.md
+++ b/readme.md
@@ -190,7 +190,7 @@ And then replace the `prerelease:version` script in [package.json](package.json)
 "prerelease:version": "dot-json distribution/manifest.json version $TRAVIS_TAG",
 ```
 
-And your extension will be published when creating a git tag, using the tag itself as version for the manifest.
+And your extension will be published when creating a git tag, using the tag itself as version for the extension.
 
 ### License
 

--- a/readme.md
+++ b/readme.md
@@ -155,7 +155,7 @@ It's possible to publish to both the Chrome Web Store and Mozilla Addons at once
 
 And then running:
 
-```sh
+``` sh
 npm run release
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,7 @@
 ## Features
 - Cross-browser builds using [webextension-polyfill][link-webext-polyfill].
 - [Auto-syncing options](#auto-syncing-options).
-- [Auto-publishing](#auto-publishing) with auto-versioning and support for manual releases.
-- Option to publish on [Git tags](#releases-on-git-tags) instead of auto-publishing.
+- [Auto-publishing](#publishing) with auto-versioning and support for manual releases.
 - [Extensive configuration documentation](#configuration).
 
 This extension template is heavily inspired from [refined-github][link-rgh], [notifier-for-github][link-ngh], and [hide-files-on-github][link-hfog] browser extensions. You can always refer to these browser extensions' source code if you find anything confusing on how to create a new extension.

--- a/readme.md
+++ b/readme.md
@@ -162,8 +162,8 @@ npm run release
 This will:
 
 1. Build the extension
-2. Create a version number based on the current UTC time, like [`19.6.16.428`](https://github.com/LinusU/utc-version#utc-version) and sets it in the manifest.json
-3. Deploy it to both stores
+1. Create a version number based on the current UTC time, like [`19.6.16.428`](https://github.com/LinusU/utc-version#utc-version) and sets it in the manifest.json
+1. Deploy it to both stores
 
 #### Auto-publishing
 
@@ -176,7 +176,7 @@ Thanks to the included [Travis file](.travis.yml), if you set up those ENVs on T
 
 If you prefer picking your versions and publishing on demand, replace the deployment in [Travis file](.travis.yml) with:
 
-```yml
+``` yml
   - provider: script
     skip_cleanup: true
     script: npm run release
@@ -186,7 +186,7 @@ If you prefer picking your versions and publishing on demand, replace the deploy
 
 And then replace the `prerelease:version` script in [package.json](package.json) with:
 
-```json
+``` json
 "prerelease:version": "dot-json distribution/manifest.json version $TRAVIS_TAG",
 ```
 


### PR DESCRIPTION
Replaces #2 
Should fix current deployment issue

1. Starts by describing local deployment (easiest)
2. Then moves onto the automated deployment on Travis
3. Then includes simple instructions to use tags.