### PR TITLE
Fix `CopyWebpackPlugin` compatibility issue

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = {
 			{
 				from: '**/*',
 				context: 'source',
-				ignore: '*.js'
+				ignore: ['*.js']
 			},
 			{
 				from: 'node_modules/webextension-polyfill/dist/browser-polyfill.min.js'


### PR DESCRIPTION
Can confirm that after implementing the very helpful fix from @ha-D the webpack config and build scripts work without issue! Didn't see a PR with the fix so I thought I would quickly submit one.

Fix copied directly from https://github.com/notlmn/browser-extension-template/issues/22#issuecomment-570781123

Thanks ha-D!