### PR TITLE
fix: correct devtool to source-map

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = {
-	devtool: 'sourcemap',
+	devtool: 'source-map',
 	stats: 'errors-only',
 	entry: {
 		background: './source/background',


### PR DESCRIPTION
I'm not sure if this typo matters or not but seems like an easy fix!
see: https://webpack.js.org/configuration/devtool/#production