### PR TITLE
Don't create tag if tests fail

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -20,6 +20,8 @@ jobs:
       created: ${{ steps.daily-version.outputs.created }}
     steps:
       - uses: actions/checkout@v2
+      - run: npm install
+      - run: npm test
       - uses: fregante/daily-version-action@v1
         name: Create tag if necessary
         id: daily-version
@@ -31,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: npm install
-    - run: npm test
+    - run: npm run build
     - name: Update extension’s meta
       env:
         VER: ${{ needs.Version.outputs.version }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,27 +13,17 @@ on:
 
 jobs:
 
-  Version:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.daily-version.outputs.version }}
-      created: ${{ steps.daily-version.outputs.created }}
-    steps:
-      - uses: actions/checkout@v2
-      - run: npm install
-      - run: npm test
-      - uses: fregante/daily-version-action@v1
-        name: Create tag if necessary
-        id: daily-version
-
   Build:
-    needs: Version
-    if: github.event_name == 'push' || needs.Version.outputs.created
+    outputs:
+      created: ${{ steps.daily-version.outputs.created }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - run: npm install
-    - run: npm run build
+    - run: npm test # This includes the build
+    - uses: fregante/daily-version-action@v1
+      name: Create tag if necessary
+      id: daily-version
     - name: Update extension’s meta
       env:
         VER: ${{ needs.Version.outputs.version }}
@@ -46,6 +36,7 @@ jobs:
 
   Chrome:
     needs: Build
+    if: github.event_name == 'push' || needs.Build.outputs.created
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v2
@@ -58,6 +49,7 @@ jobs:
 
   Firefox:
     needs: Build
+    if: github.event_name == 'push' || needs.Build.outputs.created
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v2

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -26,7 +26,7 @@ jobs:
       id: daily-version
     - name: Update extension’s meta
       env:
-        VER: ${{ needs.Version.outputs.version }}
+        VER: ${{ steps.daily-version.outputs.version }}
       run: |
         echo https://github.com/$GITHUB_REPOSITORY/tree/$VER > distribution/SOURCE_URL
         npm run version


### PR DESCRIPTION
If tests fail for whatever reason, like https://github.com/sindresorhus/refined-github/pull/3206/commits/abdbf5294671ec2b054a590179e9a083be0421fa, the tag is still created.

This should fix it, but now there are 2 sequential `npm install + npm run build`. To avoid that, the `Version`/`Build` steps need to be rethought and/or merged