### PR TITLE
Allow deployment retry

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,7 +33,7 @@ jobs:
 
   Chrome:
     needs: Build
-    if: github.event_name == 'push' || needs.Build.outputs.created
+    if: github.event_name == 'workflow_dispatch' || needs.Build.outputs.created
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v2
@@ -46,7 +46,7 @@ jobs:
 
   Firefox:
     needs: Build
-    if: github.event_name == 'push' || needs.Build.outputs.created
+    if: github.event_name == 'workflow_dispatch' || needs.Build.outputs.created
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v2


### PR DESCRIPTION
If a deployment (manual or scheduled) fails at least partially (e.g. the token was missing), the only way to retry it is to create a new commit.

---

If one of the 2 stores previously succeeded, a repeat will fail. This isn't a big deal: the CI will be "failed" but both stores will be up to date with the same version, which is what matters.

A solution to this minor problem would be to check whether the current version is already in the store’s review queue, but that's for another time (better via a dedicated CLI or Action)