### PR TITLE
Reduce release workflow with matrixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,15 +34,15 @@ jobs:
     strategy:
       matrix:
         command:
-          - release:amo
-          - release:chrome
+          - firefox
+          - chrome
     runs-on: ubuntu-latest
     steps:
       - run: npm install
       - run: npm run build
       - name: Update extension’s meta
-        run: npm run version -- ${{ steps.daily-version.outputs.version }}
-      - run: npm run ${{ matrix.command }}
+        run: npx dot-json distribution/manifest.json version ${{ steps.daily-version.outputs.version }}
+      - run: npm run release:${{ matrix.command }}
         env:
           EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 # Copied from https://github.com/notlmn/browser-extension-template/blob/master/.github/workflows/deployment.yml
-name: Deployment
+name: Publish
 
 on:
   workflow_dispatch:
@@ -37,26 +37,22 @@ jobs:
         with:
           path: distribution
 
-  Chrome:
+  Submit:
     needs: Build
     if: github.event_name == 'workflow_dispatch' || needs.Build.outputs.created
+    strategy:
+      matrix:
+        command:
+          - web-ext-submit@4
+          - chrome-webstore-upload-cli@1 upload --auto-publish
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v2
-      - run: cd artifact && npx chrome-webstore-upload-cli@1 upload --auto-publish
+      - run: cd artifact && npx ${{ matrix.command }}
         env:
           EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
-
-  Firefox:
-    needs: Build
-    if: github.event_name == 'workflow_dispatch' || needs.Build.outputs.created
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v2
-      - run: cd artifact && npx web-ext-submit@4
-        env:
           WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_API_KEY }}
           WEB_EXT_API_SECRET: ${{ secrets.WEB_EXT_API_SECRET }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
   Version:
     outputs:
       created: ${{ steps.daily-version.outputs.created }}
+      version: ${{ steps.daily-version.outputs.version }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
     - cron: '31 13 * * 3'
 
 jobs:
-  Build:
+  Version:
     outputs:
       created: ${{ steps.daily-version.outputs.created }}
     runs-on: ubuntu-latest
@@ -25,30 +25,23 @@ jobs:
       - uses: notlmn/release-with-changelog@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          template: '{commits}'
           exclude: '^Meta|^Document|^Readme|^Lint'
-      - name: Update extension’s meta
-        env:
-          VER: ${{ steps.daily-version.outputs.version }}
-        run: |
-          echo https://github.com/$GITHUB_REPOSITORY/tree/$VER > distribution/SOURCE_URL.txt
-          npm run version
-      - uses: actions/upload-artifact@v2
-        with:
-          path: distribution
 
   Submit:
-    needs: Build
+    needs: Version
     if: github.event_name == 'workflow_dispatch' || needs.Build.outputs.created
     strategy:
       matrix:
         command:
-          - web-ext-submit@4
-          - chrome-webstore-upload-cli@1 upload --auto-publish
+          - release:amo
+          - release:chrome
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
-      - run: cd artifact && npx ${{ matrix.command }}
+      - run: npm install
+      - run: npm run build
+      - name: Update extension’s meta
+        run: npm run version -- ${{ steps.daily-version.outputs.version }}
+      - run: npm run ${{ matrix.command }}
         env:
           EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 20
       - run: npm install
-      - run: npm test # This includes the build
+      - run: npm test
       - uses: fregante/daily-version-action@v1
         name: Create tag if necessary
         id: daily-version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-# Copied from https://github.com/notlmn/browser-extension-template/blob/master/.github/workflows/deployment.yml
+# Copied from https://github.com/notlmn/browser-extension-template/blob/master/.github/workflows/publish.yml
 name: Publish
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# Copied from https://github.com/notlmn/browser-extension-template/blob/master/.github/workflows/publish.yml
-name: Publish
+# Copied from https://github.com/notlmn/browser-extension-template/blob/master/.github/workflows/release.yml
+name: Release
 
 on:
   workflow_dispatch:

--- a/package.json
+++ b/package.json
@@ -6,11 +6,9 @@
 		"lint-fix": "run-p 'lint:* -- --fix'",
 		"lint:css": "stylelint source/**/*.css",
 		"lint:js": "xo",
-		"release": "VER=$(daily-version) run-s build version release:*",
-		"release:amo": "web-ext-submit --source-dir distribution",
-		"release:cws": "webstore upload --source=distribution --auto-publish",
+		"release:chrome": "cd distribution && webstore upload --auto-publish",
+		"release:firefox": "cd distribution && web-ext-submit",
 		"test": "run-s lint:* build",
-		"version": "dot-json distribution/manifest.json version $VER",
 		"watch": "webpack --mode=development --watch"
 	},
 	"xo": {


### PR DESCRIPTION
- Rename "deployment" to "release"
- Use [matrix](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategy) to reduce config
- Drop the combined release npm script

~~Untested. There's one little but ugly problem. I think this is what it looks like and there's no way to change that (mockups, "Version" no longer exists already)~~

<table><th>Before<th>After
<tr><td><img width="342" alt="before" src="https://user-images.githubusercontent.com/1402241/95524213-5c1bc400-0996-11eb-8e6d-a668639767f9.png">
<td><img width="343" alt="after" src="https://user-images.githubusercontent.com/1402241/95524215-5d4cf100-0996-11eb-9a73-8af0ebac039b.png">
