### PR TITLE
Buildfix of "Browser scripts cannot have imports or exports..."

### DIFF
--- a/source/options.html
+++ b/source/options.html
@@ -28,4 +28,4 @@
 	</div>
 </form>
 
-<script src="options.js"></script>
+<script type="module" src="options.js"></script>


### PR DESCRIPTION
Fixed build error "Browser scripts cannot have imports or exports. Use a <script type="module"> instead.".