### PR TITLE
Update deprecated manifest keys

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -5,7 +5,7 @@
 	"homepage_url": "https://github.com/fregante/browser-extension-template",
 	"manifest_version": 2,
 	"minimum_chrome_version": "80",
-	"applications": {
+	"browser_specific_settings": {
 		"gecko": {
 			"id": "awesome-extension@notlmn.github.io",
 			"strict_min_version": "80.0"
@@ -27,7 +27,7 @@
 		}
 	],
 	"options_ui": {
-		"chrome_style": true,
+		"browser_style": true,
 		"page": "options.html"
 	},
 	"background": {


### PR DESCRIPTION
Two keys used in `manifest.json` have since been renamed.

- `applications` => `browser_specific_settings` ([documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings))
- `chrome_style` => `browser_style` ([documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui))