### PR TITLE
Await form sync before initializing output color

### DIFF
--- a/source/options.js
+++ b/source/options.js
@@ -3,13 +3,11 @@ import browser from 'webextension-polyfill';
 
 import optionsStorage from './options-storage.js';
 
-optionsStorage.syncForm('#options-form');
-
 const rangeInputs = [...document.querySelectorAll('input[type="range"][name^="color"]')];
 const numberInputs = [...document.querySelectorAll('input[type="number"][name^="color"]')];
 const output = document.querySelector('.color-output');
 
-function updateColor() {
+function updateOutputColor() {
 	output.style.backgroundColor = `rgb(${rangeInputs[0].value}, ${rangeInputs[1].value}, ${rangeInputs[2].value})`;
 }
 
@@ -18,8 +16,11 @@ function updateInputField(event) {
 }
 
 for (const input of rangeInputs) {
-	input.addEventListener('input', updateColor);
+	input.addEventListener('input', updateOutputColor);
 	input.addEventListener('input', updateInputField);
 }
 
-window.addEventListener('load', updateColor);
+window.addEventListener('load', async () => {
+	await optionsStorage.syncForm('#options-form');
+	updateOutputColor();
+});

--- a/source/options.js
+++ b/source/options.js
@@ -20,7 +20,9 @@ for (const input of rangeInputs) {
 	input.addEventListener('input', updateInputField);
 }
 
-window.addEventListener('load', async () => {
+async function init() {
 	await optionsStorage.syncForm('#options-form');
 	updateOutputColor();
-});
+}
+
+init();


### PR DESCRIPTION
Since `syncForm` is an async method, we need to await for it before initializing the output color box. Before this change, the output box would always show the default colors on initialization, not the ones actually stored.

Also renamed `updateColor` -> `updateOutputColor`