### PR TITLE
Remove funding.yml

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,2 +1,0 @@
-github: fregante
-custom: https://paypal.me/bytemode


### PR DESCRIPTION
A new repository generated from this template still contains `.github/funding.yml` with your information.
I am not familiar with the detail of the funding file mechanism, but you can remove it from this repository because you manage it in your `.github` repository?