### PR TITLE
Add template cleanup workflow

### DIFF
--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -1,0 +1,34 @@
+# This is a GitHub Actions workflow for cleaning up resources in the original template. When users create
+# a new repository from the template, the workflow deletes and edits files and push a commit.
+#
+# There is no straightforward way to exclude files when a template is used, so this is a workaround for it.
+# ref. https://github.community/t/can-you-ignore-files-folders-when-making-a-repo-from-a-template/3279
+
+name: Template Cleanup
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  template-cleanup:
+    name: Template Cleanup
+    runs-on: ubuntu-latest
+    if: github.event.repository.name != 'browser-extension-template'
+    steps:
+
+      - name: Fetch Sources
+        uses: actions/checkout@v2
+
+      # Do cleanup here
+      - name: Cleanup
+        run: |
+          # Remove files
+          rm -f \
+            .github/funding.yml \
+            .github/workflows/template-cleanup.yml
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Template Cleanup

--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -2,33 +2,25 @@
 # a new repository from the template, the workflow deletes and edits files and push a commit.
 #
 # There is no straightforward way to exclude files when a template is used, so this is a workaround for it.
-# ref. https://github.community/t/can-you-ignore-files-folders-when-making-a-repo-from-a-template/3279
+# https://github.community/t/can-you-ignore-files-folders-when-making-a-repo-from-a-template/3279
 
-name: Template Cleanup
+name: Template cleanup
 on:
   push:
     branches:
       - main
 
 jobs:
-
-  template-cleanup:
-    name: Template Cleanup
+  cleanup:
     runs-on: ubuntu-latest
     if: github.event.repository.name != 'browser-extension-template'
     steps:
-
-      - name: Fetch Sources
-        uses: actions/checkout@v2
-
-      # Do cleanup here
+      - uses: actions/checkout@v2
       - name: Cleanup
         run: |
-          # Remove files
           rm -f \
             .github/funding.yml \
             .github/workflows/template-cleanup.yml
-
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Template Cleanup
+          commit_message: Template cleanup

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,8 @@ Screenshot of extension options:
 
 1. Click [<kbd>Use this template</kbd>](https://github.com/fregante/browser-extension-template/generate) to make a copy of your own. 😉
 
+Note: When you create a repository from the template, the [Template Clenup](.github/workflows/template-cleanup.yml) workflow will be triggered to delete and edit template-specific resources. Wait a moment until the workflow finishes (you will see a commit pushed with 'Template cleanup' message).
+
 ### 🛠 Build locally
 
 1. Checkout the copied repository to your local machine eg. with `git clone https://github.com/my-username/my-awesome-extension/`


### PR DESCRIPTION
Added a template cleanup workflow as discussed in https://github.com/fregante/browser-extension-template/pull/79.

The workflow is almost same as https://github.com/JetBrains/intellij-platform-plugin-template/blob/main/.github/workflows/template-cleanup.yml. It only deletes the below files for now:

- `.github/funding.yml`
- `.github/workflows/template-cleanup.yml` (workflow itself)