### PR TITLE
enable source maps via a development target

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,15 @@
 		"lint:css": "stylelint source/**/*.css",
 		"lint:js": "xo",
 		"test": "run-p lint:* build",
-		"watch": "parcel watch source/manifest.json --dist-dir distribution --no-cache --no-hmr"
+		"watch": "parcel watch source/manifest.json --target development --dist-dir distribution --no-cache --no-hmr"
+	},
+	"targets": {
+		"development": {
+			"sourceMap": {
+				"inline": true,
+				"inlineSources": true
+			}
+		}
 	},
 	"browserslist": [
 		"last 1 Chrome version",


### PR DESCRIPTION
For some reason, source maps don't work unless inlined in web extensions:

    https://parceljs.org/recipes/web-extension/#hmr

This means that development builds are not as helpful as they could be.  So add a `development` target which is activated via the normal `npm run watch` and is configured to inline source maps.

The production build is unaffected and still builds without source maps.

Closes #72.