### PR TITLE
Drop `webextension-polyfill`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,7 @@
 		"": {
 			"dependencies": {
 				"webext-base-css": "^1.4.1",
-				"webext-options-sync": "^3.1.0",
-				"webextension-polyfill": "^0.9.0"
+				"webext-options-sync": "^3.1.0"
 			},
 			"devDependencies": {
 				"@parcel/config-webextension": "^2.6.2",
@@ -7414,11 +7413,6 @@
 				"webext-detect-page": "^4.0.0"
 			}
 		},
-		"node_modules/webextension-polyfill": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.9.0.tgz",
-			"integrity": "sha512-LTtHb0yR49xa9irkstDxba4GATDAcDw3ncnFH9RImoFwDlW47U95ME5sn5IiQX2ghfaECaf6xyXM8yvClIBkkw=="
-		},
 		"node_modules/webpack": {
 			"version": "5.72.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
@@ -14051,11 +14045,6 @@
 			"requires": {
 				"webext-detect-page": "^4.0.0"
 			}
-		},
-		"webextension-polyfill": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.9.0.tgz",
-			"integrity": "sha512-LTtHb0yR49xa9irkstDxba4GATDAcDw3ncnFH9RImoFwDlW47U95ME5sn5IiQX2ghfaECaf6xyXM8yvClIBkkw=="
 		},
 		"webpack": {
 			"version": "5.72.0",

--- a/package.json
+++ b/package.json
@@ -15,24 +15,16 @@
 	],
 	"xo": {
 		"envs": [
-			"browser"
-		],
-		"rules": {
-			"no-unused-vars": [
-				"error",
-				{
-					"varsIgnorePattern": "browser"
-				}
-			]
-		}
+			"browser",
+			"webextensions"
+		]
 	},
 	"stylelint": {
 		"extends": "stylelint-config-xo"
 	},
 	"dependencies": {
 		"webext-base-css": "^1.4.1",
-		"webext-options-sync": "^3.1.0",
-		"webextension-polyfill": "^0.9.0"
+		"webext-options-sync": "^3.1.0"
 	},
 	"devDependencies": {
 		"@parcel/config-webextension": "^2.6.2",

--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,11 @@
 # browser-extension-template
 
-[link-webext-polyfill]: https://github.com/mozilla/webextension-polyfill
 [link-rgh]: https://github.com/sindresorhus/refined-github
 [link-ngh]: https://github.com/sindresorhus/notifier-for-github
 [link-hfog]: https://github.com/sindresorhus/hide-files-on-github
 [link-tsconfig]: https://github.com/sindresorhus/tsconfig
 [link-options-sync]: https://github.com/fregante/webext-options-sync
-[link-cws-keys]: https://github.com/DrewML/chrome-webstore-upload/blob/master/How%20to%20generate%20Google%20API%20keys.md
+[link-cws-keys]: https://github.com/fregante/chrome-webstore-upload/blob/main/How%20to%20generate%20Google%20API%20keys.md
 [link-amo-keys]: https://addons.mozilla.org/en-US/developers/addon/api/key
 
 > Cross-browser extension boilerplate - barebones template with Parcel 2, options handler and auto-publishing.
@@ -19,10 +18,8 @@ Screenshot of extension options:
 
 - Uses Manifest v3 ([not yet compatible with Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1578284))
 - Use npm dependencies thanks to Parcel 2.
-- Use modern promise-based `browser.*` APIs [webextension-polyfill][link-webext-polyfill].
 - [Auto-syncing options](#auto-syncing-options).
 - [Auto-publishing](#publishing) with auto-versioning and support for manual releases.
-- [Extensive configuration documentation](#configuration).
 
 ## Getting started
 

--- a/source/content.js
+++ b/source/content.js
@@ -1,7 +1,6 @@
-import browser from 'webextension-polyfill';
 import optionsStorage from './options-storage.js';
 
-console.log('💈 Content script loaded for', browser.runtime.getManifest().name);
+console.log('💈 Content script loaded for', chrome.runtime.getManifest().name);
 async function init() {
 	const options = await optionsStorage.getAll();
 	const color = 'rgb(' + options.colorRed + ', ' + options.colorGreen + ',' + options.colorBlue + ')';

--- a/source/options.js
+++ b/source/options.js
@@ -2,9 +2,6 @@
 import 'webext-base-css';
 import './options.css';
 
-// Don't forget to import this wherever you use it
-import browser from 'webextension-polyfill';
-
 import optionsStorage from './options-storage.js';
 
 const rangeInputs = [...document.querySelectorAll('input[type="range"][name^="color"]')];


### PR DESCRIPTION
Since MV3 promisified `chrome.*` APIs there's little incentive to use Firefox’ polyfill, especially since Firefox isn't supported at all currently:


- #78 


Related:

- https://github.com/mozilla/webextension-polyfill/issues/329#issuecomment-1188822881

