### PR TITLE
Restore "Template cleanup" workflow

### DIFF
--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- I suppose this fixes https://github.com/fregante/browser-extension-template/issues/90

Context: https://github.com/peaceiris/actions-gh-pages/issues/744#issuecomment-1119685318

