### PR TITLE
Turn off wait for Firefox Addon approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3
-      - run: npx web-ext@7 sign --use-submission-api --channel listed
+      - run: npx web-ext@7 sign --use-submission-api --channel listed --approval-timeout 0
         working-directory: artifact
         env:
           WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_API_KEY }}


### PR DESCRIPTION
https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#approval-timeout

I don't think it makes sense to have the GitHub action stuck waiting for approval.
As seen here: https://github.com/jetersen/bamboohr-timesheet-extension/actions/runs/10073728059/job/27848399925