### PR TITLE
Drop unnecessary section from readme 

### DIFF
--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -24,6 +24,9 @@ jobs:
           rm -f \
             .github/funding.yml \
             .github/workflows/template-cleanup.yml
+
+          # Remove the Extensions created using this template section
+          sed -i '/## Extensions created using this template/,/## License/{/## License/!d}' readme.md
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Template cleanup

--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -24,9 +24,6 @@ jobs:
           rm -f \
             .github/funding.yml \
             .github/workflows/template-cleanup.yml
-
-          # Remove the Extensions created using this template section
-          sed -i '/## Extensions created using this template/,/## License/{/## License/!d}' readme.md
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Template cleanup

--- a/readme.md
+++ b/readme.md
@@ -106,11 +106,6 @@ Thanks to the included [GitHub Action Workflows](.github/workflows), if you set 
 
 Extension icon made by [Freepik](https://www.freepik.com) from [www.flaticon.com](https://www.flaticon.com) is licensed by [CC 3.0 BY](http://creativecommons.org/licenses/by/3.0).
 
-## Extensions created using this template
-
-- [notlmn/copy-as-markdown](https://github.com/notlmn/copy-as-markdown) - Browser extension to copy hyperlinks, images, and selected text as Markdown.
-- [BenMatase/chainlink-extension](https://github.com/BenMatase/chainlink-extension) - Browser extension which helps navigating trees of Github PRs.
-
 ## License
 
 This browser extension template is released under [CC0](#license) and mentioned below. There is no `license` file included in here, but when you clone this template, you should include your own license file for the specific license you choose to use.

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,7 @@ Extension icon made by [Freepik](https://www.freepik.com) from [www.flaticon.com
 ## Extensions created using this template
 
 - [notlmn/copy-as-markdown](https://github.com/notlmn/copy-as-markdown) - Browser extension to copy hyperlinks, images, and selected text as Markdown.
+- [BenMatase/chainlink-extension](https://github.com/BenMatase/chainlink-extension) - Browser extension which helps navigating trees of Github PRs.
 
 ## License
 


### PR DESCRIPTION
Tested out the action off my fork and it worked:
![Screenshot 2025-01-12 152000](https://github.com/user-attachments/assets/d523e671-ec04-4c59-9dd8-a79f995eb82e)
