### PR TITLE
Bump versions of upload/download artifact to v4 since v3 has been deprecated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         run: npx dot-json@1 "$DIRECTORY/manifest.json" version "$DAILY_VERSION"
       - name: Ready for "submit" jobs
         if: env.DAILY_VERSION_CREATED
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ env.DIRECTORY }}
       - name: Create release
@@ -50,7 +50,7 @@ jobs:
     environment: Chrome
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
       - run: npx chrome-webstore-upload-cli@3 upload --auto-publish
         working-directory: artifact
         env:
@@ -65,7 +65,7 @@ jobs:
     environment: Firefox
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
       - run: npx web-ext@7 sign --use-submission-api --channel listed
         working-directory: artifact
         env:


### PR DESCRIPTION
Hit this in my extension so figured I'd fix it here